### PR TITLE
Add extend_sequence

### DIFF
--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -399,7 +399,9 @@ def test_extend_sequence_freq():
     with Castra(template=df) as c:
         c.extend_sequence(seq, freq='h')
         tm.assert_frame_equal(c[:], df)
-        assert len(c.partitions) == 17
+        parts = pd.date_range(start=df.index[59], freq='h',
+                              periods=16).insert(17, df.index[-1])
+        tm.assert_index_equal(c.partitions.index, parts)
 
     with Castra(template=df) as c:
         c.extend_sequence(seq, freq='d')

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -423,3 +423,24 @@ def test_extend_sequence_none():
         assert len(c.load_partition('1--5', ['a', 'b']).index) == 8
         assert len(c.load_partition('6--7', ['a', 'b']).index) == 3
         assert len(c.load_partition('9--12', ['a', 'b']).index) == 4
+
+
+def test_extend_sequence_overlap():
+    df = pd.util.testing.makeTimeDataFrame(20, 'min')
+    p1 = df.iloc[:15]
+    p2 = df.iloc[10:20]
+    seq = [p1,p2]
+    df = pd.concat(seq)
+    with Castra(template=df) as c:
+        c.extend_sequence(seq)
+        tm.assert_frame_equal(c[:], df.sort_index())
+        assert (c.partitions.index == [p.index[-1] for p in seq]).all()
+    # Check with trivial index
+    p1 = pd.DataFrame({'a': range(10), 'b': range(10)})
+    p2 = pd.DataFrame({'a': range(10, 17), 'b': range(10, 17)})
+    seq = [p1,p2]
+    df = pd.DataFrame({'a': range(17), 'b': range(17)})
+    with Castra(template=df) as c:
+        c.extend_sequence(seq)
+        tm.assert_frame_equal(c[:], df)
+        assert (c.partitions.index == [9, 16]).all()


### PR DESCRIPTION
Performs repartitioning of sequence of dataframes by `freq`.

`freq` can be either a pandas offset string, or `None`. If `None`, extend_sequence will do minimal repartitioning to ensure partitions don't split duplicate indices (i.e. `[[1, 2, 3], [3, 4, 5]] -> [[1, 2, 3, 3], [4, 5]]`).

Addresses #3, and part of #36.