### PR TITLE
Pandas compat fix to deal with RangeIndex

### DIFF
--- a/castra/core.py
+++ b/castra/core.py
@@ -116,8 +116,14 @@ class Castra(object):
                 list(template2.columns), template2.dtypes, template2.index.dtype
             self.axis_names = [template2.index.name, template2.columns.name]
 
-            self.partitions = pd.Series([], dtype='O',
-                                        index=template2.index.__class__([]))
+            # If index is a RangeIndex, use Int64Index instead
+            ind_type = type(template2.index)
+            try:
+                if isinstance(template2.index, pd.RangeIndex):
+                    ind_type = pd.Int64Index
+            except AttributeError:
+                pass
+            self.partitions = pd.Series([], dtype='O', index=ind_type([]))
             self.minimum = None
 
             # check if the given path exists already and create it if it doesn't


### PR DESCRIPTION
Pandas git master (will be 0.18.0 release, I believe) now uses `RangeIndex` objects for numerically increasing indices. In these cases, an `Int64Index` needs to be used for the partitions type. Tested and passes on both pandas 0.17.1 and pandas master.