### PR TITLE
BUG: Castra divisions/partitions

### DIFF
--- a/castra/core.py
+++ b/castra/core.py
@@ -436,7 +436,7 @@ def select_partitions(partitions, key):
     """ Select partitions from partition list given slice
 
     >>> p = pd.Series(['a', 'b', 'c', 'd', 'e'], index=[0, 10, 20, 30, 40])
-    >>> select_partitions(p, slice(3, 25))
+    >>> select_partitions(p, slice(13, 35))
     ['b', 'c', 'd']
     """
     assert key.step is None, 'step must be None but was %s' % key.step

--- a/castra/core.py
+++ b/castra/core.py
@@ -443,20 +443,18 @@ def select_partitions(partitions, key):
     start, stop = key.start, key.stop
     if start is not None:
         start = coerce_index(partitions.index.dtype, start)
-        if start in partitions.index:
-            istart = partitions.index.searchsorted(start)
-        elif partitions.index.searchsorted(start) == 0:
+        if partitions.index.searchsorted(start, side='right') == 0:
             istart = 0
         else:
-            istart = partitions.index.searchsorted(start) - 1
+            istart = partitions.index.searchsorted(start, side='right') - 1
     else:
         istart = 0
     if stop is not None:
         stop = coerce_index(partitions.index.dtype, stop)
-        if stop in partitions.index:
-            istop = partitions.index.searchsorted(stop)
+        if partitions.index.searchsorted(stop, side='right') == 0:
+            istop = 0
         else:
-            istop = partitions.index.searchsorted(stop) - 1
+            istop = partitions.index.searchsorted(stop, side='right') - 1
     else:
         istop = len(partitions) - 1
 


### PR DESCRIPTION
Hello,

See this: https://github.com/dask/dask/issues/1057

Well this grew much more than I thought it was going to. 

Castra appears to use the last index in a partition to population the divisions variable. I tried to change that, but then realized I basically could do it easier if I changed partitions. 

So here it is... 

This might not be the best way to get this to work, but it works. 

Feel free to ignore. 
