### PR TITLE
Update castra to provide proper dask metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: python
 
 matrix:
   include:
-    - python: 2.6
     - python: 2.7
     - python: 3.3
     - python: 3.4
+    - python: 3.5
 
 install:
   # Install conda


### PR DESCRIPTION
After dask https://github.com/dask/dask/pull/1422, dask dataframe
mandates that all dask dataframes are fully typed. Previously
`to_dask` wouldn't result in a fully typed dataframe, this fixes that.